### PR TITLE
Allow spaces in path name

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -1,9 +1,9 @@
 ERL ?= erl
 BASEDIR=$(CURDIR)
-PRIVDIR=$(BASEDIR)/../priv
+PRIVDIR=../priv
 
-NIF_DIR=$(BASEDIR)
-NIF_ENV=$(BASEDIR)/env.mk
+NIF_DIR=.
+NIF_ENV=./env.mk
 
 NIF_SOURCES=$(NIF_DIR)/ucol_nif.c
 NIF_OBJS=$(NIF_DIR)/ucol_nif.o


### PR DESCRIPTION
Refer also similar issue in the couch_js makefile.
Link: https://github.com/barrel-db/barrel-platform/commit/da8a93f6cb9221bf346d47a077384619d368d85c
